### PR TITLE
Upgrade pip to fix builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
     mkdir -p /opt/gallery /var/lib/gallery
 
+RUN pip install --upgrade pip
+
 WORKDIR /opt/gallery
 ADD . /opt/gallery
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ gunicorn==19.9.0
 moviepy==0.2.3.5
 imageio==2.4.0
 boto3
+werkzeug == 0.16.1


### PR DESCRIPTION
Fixes Docker build issue caused by an issue in pip 19
Issue occurred when using --no-cache-dir