### PR TITLE
Add thumbnail independent hidden badge

### DIFF
--- a/gallery/templates/view_dir.html
+++ b/gallery/templates/view_dir.html
@@ -51,6 +51,9 @@ View Directory
                             <p>Owner: {{ ldap.convert_uuid_to_displayname(child.author) }}</p>
                             <p>Date Created: {{ child.date() }}</p>
                         {% elif child_type == "File" %}
+                            {% if child.hidden %}
+                                <span class="badge">Hidden</span>
+                            {% endif %}
                             <a class="file" href="/view/file/{{ child.id }}">
                                 <img {% if child.hidden %}class="filter-hidden"{% endif %} src="/api/thumbnail/get/{{ child.id }}">
                                 <p>{{ child.get_name() }}</p>


### PR DESCRIPTION
Currently, in the directory view, the only indicator that an image is hidden is a slight greying, which is a poor indicator on images that are primarily grey.

This adds a badge to make it obvious.

## TODO
- [ ] Test on dev
- [ ] Upload screenshots
