### PR TITLE
Update directory thumbnails when deleting images

### DIFF
--- a/gallery/__init__.py
+++ b/gallery/__init__.py
@@ -458,6 +458,13 @@ def delete_file(file_id: int, auth_dict: Optional[Dict[str, Any]] = None):
     current_tags = Tag.query.filter(Tag.file_id == file_id).all()
     for tag in current_tags:
         db.session.delete(tag)
+
+    # Remove image from directory thumbnails
+    dirs = Directory.query.filter(or_(Directory.thumbnail_uuid == file_model.thumbnail_uuid, \
+        Directory.thumbnail_uuid == file_model.thumbnail_uuid[:-4]))
+    for d in dirs:
+        d.thumbnail_uuid = refresh_directory_thumbnail(d)
+
     db.session.delete(file_model)
     db.session.flush()
     db.session.commit()


### PR DESCRIPTION
Experimental.

Currently, deleting an image that's used as a directory thumbnail results in an invalid thumbnail.
This uses the thumbnail refresh logic that's used in hiding images to fix that.

Currently untested
