### PR TITLE
Properly size thumbnail images with nonexistent/unavailable sources

### DIFF
--- a/gallery/static/css/styles.css
+++ b/gallery/static/css/styles.css
@@ -38,7 +38,18 @@ h2 {
   transition: 0.3s box-shadow;
 }
 
+.album-wrapper > a {
+    display: inline-block;
+    position: relative;
+    width: 100%;
+}
+
 .album {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   transform: rotate(5deg);
   display: block;
   width: 100%;

--- a/gallery/templates/view_dir.html
+++ b/gallery/templates/view_dir.html
@@ -42,6 +42,8 @@ View Directory
                         {% if child_type == "Directory" %}
                             <div class="album-wrapper">
                                 <a href="/view/dir/{{ child.id }}">
+                                    <!-- Dummy div, needed for ensuring proper element sizing (see issue #80) -->
+                                    <div style="margin-top:100%"></div>
                                     <img class="album" src="/api/thumbnail/get/dir/{{ child.id }}">
                                 </a>
                             </div>


### PR DESCRIPTION
Adds some HTML and CSS to ensure that thumbnail images with bad sources
are correctly sized. Resolves #80.

Fix visualization (see #80 for an example of what it looked like prior):
![Example of what was fixed (see #80 for an example of what it looked like prior)](https://user-images.githubusercontent.com/25161597/128657448-2e74d40c-deb3-4beb-9824-cafb1502b160.png)
