### PR TITLE
Use setup.cfg as version source of truth

### DIFF
--- a/gallery/_version.py
+++ b/gallery/_version.py
@@ -1,6 +1,8 @@
 from os import environ as env
+from setuptools.config.setupcfg import read_configuration
 
-__version__ = "2.2.0"
+config = read_configuration('setup.cfg')
+__version__ = config["metadata"]["version"]
 
 BUILD_REFERENCE = env.get("OPENSHIFT_BUILD_REFERENCE")
 COMMIT_HASH = env.get("OPENSHIFT_BUILD_COMMIT")


### PR DESCRIPTION
I noticed that gallery was still reporting a version of 2.2.0, and that I had not known to update the version number in `gallery/_version.py`
