### PR TITLE
fix: use thumbnail_uuid for the thumbnail instead of s3_id

### DIFF
--- a/gallery/__init__.py
+++ b/gallery/__init__.py
@@ -866,7 +866,11 @@ def display_thumbnail(file_id: int, auth_dict: Optional[Dict[str, Any]] = None):
 
     file_model = File.query.filter(File.id == file_id).first()
 
-    link = storage_interface.get_link("thumbnails/{}".format(file_model.s3_id))
+    thumbnail_uuid = file_model.thumbnail_uuid
+    if len(thumbnail_uuid.split('.')) > 1:
+        thumbnail_uuid = thumbnail_uuid.split('.')[0]
+
+    link = storage_interface.get_link("thumbnails/{}".format(thumbnail_uuid))
     if "LOCAL_STORAGE_PATH" in app.config:
         link = "http://" + app.config["SERVER_NAME"] + link
     req = requests.get(link)


### PR DESCRIPTION
## What

- Change from using the `s3_id` to `thumbnail_uuid`
- This code is directly copied from the dir thumbnail function

## Why

`thumbnail_uuid` is pretty much always equal to `s3_id` (save for the file extension which for some reason exists in a column called `thumbnail_uuid`)

```sql
SELECT s3_id, thumbnail_uuid FROM public.files WHERE s3_id != regexp_replace(thumbnail_uuid, '\.[^.]+$', '')
```

This query yields a single row - the row I modified to get a higher quality video in manually because of our 1Gb upload cap.

## Test Plan

- Noah

## Env Vars

N/A

## Documentation

Shnope

## Checklist

- [ ] Tested all changes locally
