### PR TITLE
Decrease max file size for uploads to 5GB

### DIFF
--- a/gallery/templates/view_dir.html
+++ b/gallery/templates/view_dir.html
@@ -252,7 +252,7 @@ Dropzone.autoDiscover = false;
             uploadMultiple: false,
             autoProcessQueue: false,
             parallelUploads: 3,
-            maxFilesize: 10 * 1024,
+            maxFilesize: 5 * 1024,
             chunking: true,
             forceChunking: true,
             chunkSize: 10 * 1024 * 1024,


### PR DESCRIPTION
## What

Reduce maximum file size limit from 10GB to 5GB

## Why

S3 has a limit of 5GB for a single upload. Gallery currently uploads stuff to pods first and then S3, this needs to be changed and that is not straightforward.

## Test Plan

ran locally. i mean it's just a value change

## Env Vars

nope

## Documentation

nuh huh

## Checklist

- [x] Tested all changes locally
